### PR TITLE
remove engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,8 +37,5 @@
     "env": [
       "mocha"
     ]
-  },
-  "engines": {
-    "node": "8.x"
   }
 }


### PR DESCRIPTION
The project currently supports all maintained Node versions, but this can't be expressed through semver: 6 is maintained (LTS), 7 is not, 8 is.
The field is advisory anyway, so just remove it.