### PR TITLE
toString revision

### DIFF
--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -20,7 +20,7 @@ module.exports = class InvocationData {
 
 function defineImmutableProperty (object, key, value) {
   Object.defineProperty(object, key, {
-    value: value,
+    value,
     writable: false,
     configurable: false
   })

--- a/test/toString.js
+++ b/test/toString.js
@@ -23,4 +23,9 @@ describe('toString method', function () {
   it('should always return the same toString()', function () {
     wrap.the(nop).toString.should.equal(wrap.the(nop).toString)
   })
+
+  it('should not throw directly calling Function.prototype.toString on wrapped function', function () {
+    const wrapped = wrap.the(nop)
+    Function.prototype.toString.call(wrapped)
+  })
 })


### PR DESCRIPTION
With [`Function.prototype.toString()` revision](https://tc39.es/Function-prototype-toString-revision/), [issue 45](https://github.com/LucaFranceschini/wrapper-roo/issues/45) is partially solved: it doesn't throw anymore, though the result is still different.
A test case against exception throw is added.